### PR TITLE
add sam3 as an detector option

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,15 @@ pip install 'git+https://github.com/facebookresearch/detectron2.git@a1ce2f9' --n
 pip install git+https://github.com/microsoft/MoGe.git
 ```
 
+### 6. Install SAM3 (Optional)
+```bash
+# this is a minimal installation of sam3 only to support its inference 
+git clone https://github.com/facebookresearch/sam3.git
+cd sam3
+pip install -e .
+pip install decord psutil
+```
+
 
 ## Getting Model Checkpoints
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,20 @@ You can also run our demo script for model inference and visualization:
 # Download assets from HuggingFace
 hf download facebook/sam-3d-body-dinov3 --local-dir checkpoints/sam-3d-body-dinov3
 
-# Run demo script
+# Run demo script with default ViTdet detector and MoGe2 FOV model
 python demo.py \
     --image_folder <path_to_images> \
     --output_folder <path_to_output> \
     --checkpoint_path ./checkpoints/sam-3d-body-dinov3/model.ckpt \
     --mhr_path ./checkpoints/sam-3d-body-dinov3/assets/mhr_model.pt
+
+# To use SAM3 as the detector to align with online playground of SAM3D
+python demo.py \
+    --image_folder <path_to_images> \
+    --output_folder <path_to_output> \
+    --checkpoint_path ./checkpoints/sam-3d-body-dinov3/model.ckpt \
+    --mhr_path ./checkpoints/sam-3d-body-dinov3/assets/mhr_model.pt \
+    --detector_name sam3
 ```
 
 For a complete demo with visualization, see [notebook/demo_human.ipynb](notebook/demo_human.ipynb).

--- a/demo.py
+++ b/demo.py
@@ -47,7 +47,8 @@ def main(args):
         human_detector = HumanDetector(
             name=args.detector_name, device=device, path=detector_path
         )
-    if len(segmentor_path):
+    
+    if (args.segmentor_name == "sam2" and len(segmentor_path)) or args.segmentor_name != "sam2":
         from tools.build_sam import HumanSegmentor
 
         human_segmentor = HumanSegmentor(


### PR DESCRIPTION
Add the support of using SAM3 as detector to align with SAM3D's behavior on Online Playground. In this implementation, I hard coded `scale_factor=1.2` to rescale the bounding boxes extracted from SAM3D mask as the SAM3D input.

Test on our offline demo images set suggests that SAM3D performs better than our default detector ViTDet on finding smaller and rare-view human targets.