### PR TITLE
Fix CPU support by removing hardcoded CUDA calls

### DIFF
--- a/sam_3d_body/models/meta_arch/sam3d_body.py
+++ b/sam_3d_body/models/meta_arch/sam3d_body.py
@@ -1031,7 +1031,7 @@ class SAM3DBody(BaseModel):
                 torch.meshgrid(torch.arange(H), torch.arange(W), indexing="xy"), dim=2
             )[None, None, :, :, :]
             .repeat(B, N, 1, 1, 1)
-            .cuda()
+            .to(self.device)
         )  # B x N x H x W x 2
         meshgrid_xy = (
             meshgrid_xy / batch["affine_trans"][:, :, None, None, [0, 1], [0, 1]]
@@ -1243,7 +1243,7 @@ class SAM3DBody(BaseModel):
         batch_lhand = prepare_batch(
             flipped_img, transform_hand, left_xyxy, cam_int=cam_int.clone()
         )
-        batch_lhand = recursive_to(batch_lhand, "cuda")
+        batch_lhand = recursive_to(batch_lhand, self.device.type)
         lhand_output = self.forward_step(batch_lhand, decoder_type="hand")
 
         # Unflip output
@@ -1279,17 +1279,17 @@ class SAM3DBody(BaseModel):
         batch_rhand = prepare_batch(
             img, transform_hand, right_xyxy, cam_int=cam_int.clone()
         )
-        batch_rhand = recursive_to(batch_rhand, "cuda")
+        batch_rhand = recursive_to(batch_rhand, self.device.type)
         rhand_output = self.forward_step(batch_rhand, decoder_type="hand")
 
         # Step 3. replace hand pose estimation from the body decoder.
         ## CRITERIA 1: LOCAL WRIST POSE DIFFERENCE
         joint_rotations = pose_output["mhr"]["joint_global_rots"]
         ### Get lowarm
-        lowarm_joint_idxs = torch.LongTensor([76, 40]).cuda()  # left, right
+        lowarm_joint_idxs = torch.LongTensor([76, 40]).to(self.device)  # left, right
         lowarm_joint_rotations = joint_rotations[:, lowarm_joint_idxs]  # B x 2 x 3 x 3
         ### Get zero-wrist pose
-        wrist_twist_joint_idxs = torch.LongTensor([77, 41]).cuda()  # left, right
+        wrist_twist_joint_idxs = torch.LongTensor([77, 41]).to(self.device)  # left, right
         wrist_zero_rot_pose = (
             lowarm_joint_rotations
             @ self.head_pose.joint_rotation[wrist_twist_joint_idxs]
@@ -1505,11 +1505,11 @@ class SAM3DBody(BaseModel):
         )[1]
 
         # Get lowarm
-        lowarm_joint_idxs = torch.LongTensor([76, 40]).cuda()  # left, right
+        lowarm_joint_idxs = torch.LongTensor([76, 40]).to(self.device)  # left, right
         lowarm_joint_rotations = joint_rotations[:, lowarm_joint_idxs]  # B x 2 x 3 x 3
 
         # Get zero-wrist pose
-        wrist_twist_joint_idxs = torch.LongTensor([77, 41]).cuda()  # left, right
+        wrist_twist_joint_idxs = torch.LongTensor([77, 41]).to(self.device)  # left, right
         wrist_zero_rot_pose = (
             lowarm_joint_rotations
             @ self.head_pose.joint_rotation[wrist_twist_joint_idxs]

--- a/sam_3d_body/sam_3d_body_estimator.py
+++ b/sam_3d_body/sam_3d_body_estimator.py
@@ -157,7 +157,7 @@ class SAM3DBodyEstimator:
         batch = prepare_batch(img, self.transform, boxes, masks, masks_score)
 
         #################### Run model inference on an image ####################
-        batch = recursive_to(batch, "cuda")
+        batch = recursive_to(batch, self.device.type)
         self.model._initialize_batch(batch)
 
         # Handle camera intrinsics


### PR DESCRIPTION
This PR fixes CPU support by removing all hard-coded CUDA device calls in the model execution path. Several modules previously forced tensors to "cuda" (e.g., via .cuda(), recursive_to(..., "cuda"), or device="cuda"), which caused runtime failures when no GPU was available.

All these occurrences have been replaced with device-agnostic logic relying on "self.device".

Also tested in a Docker container without GPU support, confirming that inference runs successfully on CPU without errors.