### PR TITLE
Add hand-only inference option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ SAM 3D Body is one part of SAM 3D, a pair of models for object and human mesh re
 # SAM 3D Body: Robust Full-Body Human Mesh Recovery
 
 <p align="left">
+<a href="https://arxiv.org/abs/2602.15989"><img src="https://img.shields.io/badge/arXiv-2602.15989-b31b1b.svg" alt="arXiv"></a>
 <a href="https://ai.meta.com/research/publications/sam-3d-body-robust-full-body-human-mesh-recovery/"><img src='https://img.shields.io/badge/Meta_AI-Paper-4A90E2?logo=meta&logoColor=white' alt='Paper'></a>
 <a href="https://ai.meta.com/blog/sam-3d/"><img src='https://img.shields.io/badge/Project_Page-Blog-9B72F0?logo=googledocs&logoColor=white' alt='Blog'></a>
 <a href="https://huggingface.co/datasets/facebook/sam-3d-body-dataset"><img src='https://img.shields.io/badge/🤗_Hugging_Face-Dataset-F59500?logoColor=white' alt='Dataset'></a>
@@ -78,7 +79,7 @@ See [INSTALL.md](INSTALL.md) for instructions for python environment setup and m
 
 ## Getting Started
 
-3DB can reconstruct 3D full-body human mesh from a single image, optionally with keypoint/mask prompts and/or hand refinement from the hand decoder. 
+3DB can reconstruct 3D full-body human mesh from a single image, optionally with keypoint/mask prompts and/or hand refinement from the hand decoder.
 
 For a quick start, run our demo script for model inference and visualization with models from [Hugging Face](https://huggingface.co/facebook) (please make sure to follow [INSTALL.md](INSTALL.md) to request access to our checkpoints.).
 
@@ -131,7 +132,7 @@ For a complete demo with visualization, see [notebook/demo_human.ipynb](notebook
 
 The table below shows the performance of SAM 3D Body checkpoints released on 11/19/2025.
 
-|      **Backbone (size)**       | **3DPW (MPJPE)** |    **EMDB (MPJPE)**     | **RICH (PVE)** | **COCO (PCK@.05)** |  **LSPET (PCK@.05)** | **Freihand (PA-MPJPE)** 
+|      **Backbone (size)**       | **3DPW (MPJPE)** |    **EMDB (MPJPE)**     | **RICH (PVE)** | **COCO (PCK@.05)** |  **LSPET (PCK@.05)** | **Freihand (PA-MPJPE)**
 | :------------------: | :----------: | :--------------------: | :-----------------: | :----------------: | :----------------: | :----------------: |
 |  DINOv3-H+ (840M) <br /> ([config](https://huggingface.co/facebook/sam-3d-body-dinov3/blob/main/model_config.yaml), [checkpoint](https://huggingface.co/facebook/sam-3d-body-dinov3/blob/main/model.ckpt))   |      54.8      |          61.7         |       60.3        |       86.5        | 68.0 | 5.5
 |   ViT-H  (631M) <br /> ([config](https://huggingface.co/facebook/sam-3d-body-vith/blob/main/model_config.yaml), [checkpoint](https://huggingface.co/facebook/sam-3d-body-vith/blob/main/model.ckpt))    |     54.8   |         62.9         |       61.7        |        86.8       | 68.9 |  5.5
@@ -164,10 +165,10 @@ Vivian Lee, George Orlin, Nikhila Ravi, Andrew Westbury, Jyun-Ting Song, Zejia W
 If you use SAM 3D Body or the SAM 3D Body dataset in your research, please use the following BibTeX entry.
 
 ```bibtex
-@article{yang2025sam3dbody,
+@article{yang2026sam3dbody,
   title={SAM 3D Body: Robust Full-Body Human Mesh Recovery},
   author={Yang, Xitong and Kukreja, Devansh and Pinkus, Don and Sagar, Anushka and Fan, Taosha and Park, Jinhyung and Shin, Soyong and Cao, Jinkun and Liu, Jiawei and Ugrinovic, Nicolas and Feiszli, Matt and Malik, Jitendra and Dollar, Piotr and Kitani, Kris},
-  journal={arXiv preprint; identifier to be added},
-  year={2025}
+  journal={arXiv preprint arXiv:2602.15989},
+  year={2026}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ python demo.py \
     --detector_name sam3
 ```
 
+You can run inference focusing only on hands by setting the `--inference_type` argument:
+
+```bash
+python demo.py \
+    --image_folder <path_to_images> \
+    --output_folder <path_to_output> \
+    --checkpoint_path ./checkpoints/sam-3d-body-dinov3/model.ckpt \
+    --mhr_path ./checkpoints/sam-3d-body-dinov3/assets/mhr_model.pt \
+    --inference_type hand
+```
+For best performance in hand-only inference, we recommend using tightly cropped hand images with minimal or no visible body context.
+
 You can also try the following lines of code with models loaded directly from [Hugging Face](https://huggingface.co/facebook)
 
 ```python

--- a/demo.py
+++ b/demo.py
@@ -89,6 +89,7 @@ def main(args):
             image_path,
             bbox_thr=args.bbox_thresh,
             use_mask=args.use_mask,
+            inference_type=args.inference_type,
         )
 
         img = cv2.imread(image_path)
@@ -185,6 +186,13 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Use mask-conditioned prediction (segmentation mask is automatically generated from bbox)",
+    )
+    parser.add_argument(
+        "--inference_type",
+        type=str,
+        default="full",
+        choices=["full", "hand"],
+        help="Type of inference to run: 'full' (default) or 'hand' for hand-only inference",
     )
     args = parser.parse_args()
 

--- a/sam_3d_body/sam_3d_body_estimator.py
+++ b/sam_3d_body/sam_3d_body_estimator.py
@@ -188,7 +188,11 @@ class SAM3DBodyEstimator:
         else:
             pose_output = outputs
 
-        out = pose_output["mhr"]
+        if inference_type == "hand":
+            out = pose_output["mhr_hand"]
+        else:
+            out = pose_output["mhr"]
+
         out = recursive_to(out, "cpu")
         out = recursive_to(out, "numpy")
         all_out = []


### PR DESCRIPTION
This PR adds support for hand-only inference in the demo pipeline.

### Changes
- Add `--inference_type` argument to `demo.py`
- Enable hand-only inference path in the estimator
- Update `README.md` with usage instructions
- Recommend using tightly cropped hand images for better alignment

### Context
This addresses the mismatch between hand-crop inference behavior and the description in the paper (Figure 7), where the model is expected to produce hand-aligned outputs for cropped hand inputs.

Resolves #120