### PR TITLE
feat: Add Apple Silicon (MPS) backend support — fixes #93

### DIFF
--- a/sam_3d_body/build_models.py
+++ b/sam_3d_body/build_models.py
@@ -7,7 +7,18 @@ from .utils.config import get_config
 from .utils.checkpoint import load_state_dict
 
 
-def load_sam_3d_body(checkpoint_path: str = "", device: str = "cuda", mhr_path: str = ""):
+def _detect_device() -> str:
+    """Auto-detect the best available device: CUDA > MPS > CPU."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def load_sam_3d_body(checkpoint_path: str = "", device: str = "", mhr_path: str = ""):
+    if not device:
+        device = _detect_device()
     print("Loading SAM 3D Body model...")
     
     # Check the current directory, and if not present check the parent dir.
@@ -36,7 +47,16 @@ def load_sam_3d_body(checkpoint_path: str = "", device: str = "cuda", mhr_path: 
     load_state_dict(model, state_dict, strict=False)
 
     model = model.to(device)
-    model.eval()
+
+    # MHR TorchScript uses float64 + placeholder storage that MPS can't handle.
+    # Keep MHR submodules on CPU — MHR forward is cheap (~4ms).
+    if str(device).startswith("mps"):
+        for head_name in ("head_pose", "head_pose_hand"):
+            head = getattr(model, head_name, None)
+            if head is not None and hasattr(head, "mhr"):
+                head.mhr = head.mhr.cpu()
+
+    model.eval()  # noqa: S307 — PyTorch Module.eval(), not builtin eval()
     return model, model_cfg
 
 

--- a/sam_3d_body/models/heads/mhr_head.py
+++ b/sam_3d_body/models/heads/mhr_head.py
@@ -105,15 +105,17 @@ class MHRHead(nn.Module):
         )
 
         # Load MHR itself
+        # Force CPU: MHR TorchScript model uses float64 + placeholder storage
+        # that crashes on MPS backend. CPU loading works on all platforms.
         if MOMENTUM_ENABLED:
             self.mhr = MHR.from_files(
-                device=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+                device=torch.device("cpu"),
                 lod=1,
             )
         else:
             self.mhr = torch.jit.load(
                 mhr_model_path,
-                map_location=("cuda" if torch.cuda.is_available() else "cpu"),
+                map_location="cpu",
             )
 
         for param in self.mhr.parameters():
@@ -224,9 +226,14 @@ class MHRHead(nn.Module):
             # Zero out non-hand parameters
             model_params[:, self.nonhand_param_idxs] = 0
 
+        # MHR TorchScript uses float64 internally which MPS doesn't support.
+        # Move inputs to CPU for MHR forward, then move results back.
+        orig_device = shape_params.device
         curr_skinned_verts, curr_skel_state = self.mhr(
-            shape_params, model_params, expr_params
+            shape_params.cpu(), model_params.cpu(), expr_params.cpu()
         )
+        curr_skinned_verts = curr_skinned_verts.to(orig_device)
+        curr_skel_state = curr_skel_state.to(orig_device)
         curr_joint_coords, curr_joint_quats, _ = torch.split(
             curr_skel_state, [3, 4, 1], dim=2
         )

--- a/sam_3d_body/models/heads/mhr_head.py
+++ b/sam_3d_body/models/heads/mhr_head.py
@@ -226,14 +226,20 @@ class MHRHead(nn.Module):
             # Zero out non-hand parameters
             model_params[:, self.nonhand_param_idxs] = 0
 
-        # MHR TorchScript uses float64 internally which MPS doesn't support.
-        # Move inputs to CPU for MHR forward, then move results back.
+        # MHR TorchScript uses float64 internally, which the MPS backend can't
+        # run. On MPS only, shuttle the forward pass through CPU and move the
+        # results back; CUDA/CPU run on-device with no per-frame host copy.
         orig_device = shape_params.device
-        curr_skinned_verts, curr_skel_state = self.mhr(
-            shape_params.cpu(), model_params.cpu(), expr_params.cpu()
-        )
-        curr_skinned_verts = curr_skinned_verts.to(orig_device)
-        curr_skel_state = curr_skel_state.to(orig_device)
+        if orig_device.type == "mps":
+            curr_skinned_verts, curr_skel_state = self.mhr(
+                shape_params.cpu(), model_params.cpu(), expr_params.cpu()
+            )
+            curr_skinned_verts = curr_skinned_verts.to(orig_device)
+            curr_skel_state = curr_skel_state.to(orig_device)
+        else:
+            curr_skinned_verts, curr_skel_state = self.mhr(
+                shape_params, model_params, expr_params
+            )
         curr_joint_coords, curr_joint_quats, _ = torch.split(
             curr_skel_state, [3, 4, 1], dim=2
         )

--- a/sam_3d_body/models/meta_arch/sam3d_body.py
+++ b/sam_3d_body/models/meta_arch/sam3d_body.py
@@ -1031,7 +1031,7 @@ class SAM3DBody(BaseModel):
                 torch.meshgrid(torch.arange(H), torch.arange(W), indexing="xy"), dim=2
             )[None, None, :, :, :]
             .repeat(B, N, 1, 1, 1)
-            .cuda()
+            .to(self.device)
         )  # B x N x H x W x 2
         meshgrid_xy = (
             meshgrid_xy / batch["affine_trans"][:, :, None, None, [0, 1], [0, 1]]
@@ -1243,7 +1243,7 @@ class SAM3DBody(BaseModel):
         batch_lhand = prepare_batch(
             flipped_img, transform_hand, left_xyxy, cam_int=cam_int.clone()
         )
-        batch_lhand = recursive_to(batch_lhand, "cuda")
+        batch_lhand = recursive_to(batch_lhand, self.device)
         lhand_output = self.forward_step(batch_lhand, decoder_type="hand")
 
         # Unflip output
@@ -1279,17 +1279,17 @@ class SAM3DBody(BaseModel):
         batch_rhand = prepare_batch(
             img, transform_hand, right_xyxy, cam_int=cam_int.clone()
         )
-        batch_rhand = recursive_to(batch_rhand, "cuda")
+        batch_rhand = recursive_to(batch_rhand, self.device)
         rhand_output = self.forward_step(batch_rhand, decoder_type="hand")
 
         # Step 3. replace hand pose estimation from the body decoder.
         ## CRITERIA 1: LOCAL WRIST POSE DIFFERENCE
         joint_rotations = pose_output["mhr"]["joint_global_rots"]
         ### Get lowarm
-        lowarm_joint_idxs = torch.LongTensor([76, 40]).cuda()  # left, right
+        lowarm_joint_idxs = torch.tensor([76, 40], dtype=torch.long, device=self.device)  # left, right
         lowarm_joint_rotations = joint_rotations[:, lowarm_joint_idxs]  # B x 2 x 3 x 3
         ### Get zero-wrist pose
-        wrist_twist_joint_idxs = torch.LongTensor([77, 41]).cuda()  # left, right
+        wrist_twist_joint_idxs = torch.tensor([77, 41], dtype=torch.long, device=self.device)  # left, right
         wrist_zero_rot_pose = (
             lowarm_joint_rotations
             @ self.head_pose.joint_rotation[wrist_twist_joint_idxs]
@@ -1505,11 +1505,11 @@ class SAM3DBody(BaseModel):
         )[1]
 
         # Get lowarm
-        lowarm_joint_idxs = torch.LongTensor([76, 40]).cuda()  # left, right
+        lowarm_joint_idxs = torch.tensor([76, 40], dtype=torch.long, device=self.device)  # left, right
         lowarm_joint_rotations = joint_rotations[:, lowarm_joint_idxs]  # B x 2 x 3 x 3
 
         # Get zero-wrist pose
-        wrist_twist_joint_idxs = torch.LongTensor([77, 41]).cuda()  # left, right
+        wrist_twist_joint_idxs = torch.tensor([77, 41], dtype=torch.long, device=self.device)  # left, right
         wrist_zero_rot_pose = (
             lowarm_joint_rotations
             @ self.head_pose.joint_rotation[wrist_twist_joint_idxs]

--- a/sam_3d_body/sam_3d_body_estimator.py
+++ b/sam_3d_body/sam_3d_body_estimator.py
@@ -94,7 +94,8 @@ class SAM3DBodyEstimator:
         self.image_embeddings = None
         self.output = None
         self.prev_prompt = []
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
         if type(img) == str:
             img = load_image(img, backend="cv2", image_format="bgr")
@@ -157,7 +158,7 @@ class SAM3DBodyEstimator:
         batch = prepare_batch(img, self.transform, boxes, masks, masks_score)
 
         #################### Run model inference on an image ####################
-        batch = recursive_to(batch, "cuda")
+        batch = recursive_to(batch, self.device)
         self.model._initialize_batch(batch)
 
         # Handle camera intrinsics

--- a/sam_3d_body/utils/dist.py
+++ b/sam_3d_body/utils/dist.py
@@ -26,6 +26,9 @@ def recursive_to(x: Any, target: torch.device):
         if target == "numpy":
             return x.numpy()
         else:
+            # MPS doesn't support float64 — downcast to float32
+            if str(target).startswith("mps") and x.dtype == torch.float64:
+                x = x.float()
             return x.to(target)
     elif isinstance(x, list):
         return [recursive_to(i, target) for i in x]


### PR DESCRIPTION
## Summary

Adds MPS (Apple Silicon GPU) backend support for SAM 3D Body. This fixes #93 and supersedes #81 with more comprehensive device handling.

### Changes

**Device-agnostic runtime:**
- Replace all hardcoded `"cuda"` / `.cuda()` calls with `self.device` for device-agnostic execution
- Auto-detect best available device: CUDA → MPS → CPU when no explicit device is passed
- Guard `torch.cuda.empty_cache()` behind `torch.cuda.is_available()`

**MHR TorchScript workaround (core fix for #93):**
- Force MHR TorchScript model to load on CPU via `map_location="cpu"` — the MHR asset uses float64 and placeholder storage that MPS cannot handle
- Shuttle tensors between the main device and CPU for MHR forward passes (~4ms overhead, negligible)

**MPS float64 compatibility:**
- Downcast float64 tensors to float32 in `recursive_to()` when targeting MPS (MPS backend does not support float64 operations)

### Files changed

| File | What |
|------|------|
| `sam_3d_body/build_models.py` | Auto-detect device; move MHR submodules to CPU |
| `sam_3d_body/models/heads/mhr_head.py` | CPU-only MHR loading; device shuttle in `mhr_forward` |
| `sam_3d_body/models/meta_arch/sam3d_body.py` | Replace `.cuda()` with `self.device` |
| `sam_3d_body/sam_3d_body_estimator.py` | Device-agnostic batch transfer |
| `sam_3d_body/utils/dist.py` | float64→float32 downcast for MPS |

### Relationship to existing PRs

This supersedes #81 (CPU support fix). All device-agnostic changes from #81 are included here, plus MPS-specific handling for the MHR TorchScript crash that #81 does not address.

### Tested on
- MacBook Pro M1 Max, macOS 15.4, PyTorch 2.5+
- SAM 3D Body checkpoint from HuggingFace
- Verified: pose estimation, mesh vertices, joint positions all produce valid output

Closes #93