### PR TITLE
Implemented CPU Offloading

### DIFF
--- a/sam_3d_body/build_models.py
+++ b/sam_3d_body/build_models.py
@@ -1,51 +1,199 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 import os
 import torch
-
 from .models.meta_arch import SAM3DBody
 from .utils.config import get_config
 from .utils.checkpoint import load_state_dict
 
 
-def load_sam_3d_body(checkpoint_path: str = "", device: str = "cuda", mhr_path: str = ""):
-    print("Loading SAM 3D Body model...")
-    
-    # Check the current directory, and if not present check the parent dir.
+# ---------------------------------------------------------------------------
+# CPU offload wrapper
+# ---------------------------------------------------------------------------
+
+class CPUOffloadWrapper(torch.nn.Module):
+    """
+    Keeps model weights in CPU RAM between inference calls.
+    On each forward(), moves weights to `inference_device`, runs the pass,
+    then moves everything back to CPU and clears the CUDA cache.
+
+    This means your GPU only needs enough VRAM for the active forward pass,
+    not to hold the full model persistently.
+    """
+
+    def __init__(self, model: torch.nn.Module, inference_device: torch.device):
+        super().__init__()
+        self.inner = model.cpu()
+        self.inference_device = inference_device
+
+    @staticmethod
+    def _move_non_persistent_buffers(module: torch.nn.Module, device: torch.device):
+        """
+        Recursively move all non-persistent buffers to `device`.
+
+        PyTorch's .to() intentionally skips buffers registered with
+        persistent=False (e.g. image_mean / image_std in SAM3DBody).
+        These are tracked in the internal _non_persistent_buffers_set set
+        on each submodule. We move them manually so they match the device
+        of the parameters during the forward pass.
+        """
+        for submodule in module.modules():
+            non_persistent = getattr(submodule, "_non_persistent_buffers_set", set())
+            for name in non_persistent:
+                buf = getattr(submodule, name, None)
+                if isinstance(buf, torch.Tensor):
+                    setattr(submodule, name, buf.to(device))
+
+    def forward(self, *args, **kwargs):
+        # Move parameters + persistent buffers to GPU
+        self.inner.to(self.inference_device)
+        # Move non-persistent buffers (e.g. image_mean/image_std) separately —
+        # .to() silently skips these, causing device mismatch errors.
+        self._move_non_persistent_buffers(self.inner, self.inference_device)
+        try:
+            args = _to_device(args, self.inference_device)
+            kwargs = _to_device(kwargs, self.inference_device)
+            out = self.inner(*args, **kwargs)
+        finally:
+            # Always move everything back to CPU, even on exception.
+            self.inner.cpu()
+            self._move_non_persistent_buffers(self.inner, torch.device("cpu"))
+            if self.inference_device.type == "cuda":
+                torch.cuda.empty_cache()
+        return out
+
+    # Proxy attribute access so callers (e.g. estimator.faces) still work.
+    def __getattr__(self, name: str):
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(self.inner, name)
+
+
+def _to_device(obj, device):
+    """Recursively move tensors in nested dicts / lists / tuples to device."""
+    if isinstance(obj, torch.Tensor):
+        return obj.to(device)
+    if isinstance(obj, dict):
+        return {k: _to_device(v, device) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_to_device(v, device) for v in obj)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Main loader
+# ---------------------------------------------------------------------------
+
+def load_sam_3d_body(
+    checkpoint_path: str = "",
+    device: str = "cuda",
+    mhr_path: str = "",
+    offload_mode: str = "cpu",   # "none" | "cpu" | "auto"
+):
+    """
+    Load the SAM 3D Body model with optional CPU/RAM offloading.
+
+    Parameters
+    ----------
+    checkpoint_path : str
+        Path to the model .ckpt file.
+    device : str
+        Target device for inference (e.g. "cuda", "cuda:0", "cpu").
+    mhr_path : str
+        Path to the MHR model .pt file.
+    offload_mode : str
+        "none" – original behaviour, model fully resident on `device`.
+        "cpu"  – weights stay in CPU RAM; moved to `device` only during
+                 each forward() call, then returned to CPU afterwards.
+                 Requires only enough VRAM for a single forward pass.
+        "auto" – uses HuggingFace Accelerate to split layers across
+                 GPU + CPU RAM automatically. Requires: pip install accelerate
+    """
+    print(f"Loading SAM 3D Body model... (offload_mode={offload_mode!r})")
+
+    # ---- config --------------------------------------------------------
     model_cfg = os.path.join(os.path.dirname(checkpoint_path), "model_config.yaml")
     if not os.path.exists(model_cfg):
-        # Looks at parent dir
         model_cfg = os.path.join(
             os.path.dirname(os.path.dirname(checkpoint_path)), "model_config.yaml"
         )
-
     model_cfg = get_config(model_cfg)
-
-    # Disable face for inference
     model_cfg.defrost()
     model_cfg.MODEL.MHR_HEAD.MHR_MODEL_PATH = mhr_path
     model_cfg.freeze()
 
-    # Initialze the model
+    # ---- build model skeleton (always on CPU) ---------------------------
     model = SAM3DBody(model_cfg)
 
+    # ---- load checkpoint (always to CPU RAM first) ----------------------
+    # map_location="cpu" ensures the raw checkpoint never occupies VRAM,
+    # regardless of which offload_mode is chosen.
     checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
-    if "state_dict" in checkpoint:
-        state_dict = checkpoint["state_dict"]
-    else:
-        state_dict = checkpoint
+    state_dict = checkpoint.get("state_dict", checkpoint)
     load_state_dict(model, state_dict, strict=False)
+    del checkpoint, state_dict   # free CPU RAM immediately
 
-    model = model.to(device)
     model.eval()
+
+    # ---- apply offload strategy ----------------------------------------
+    inference_device = torch.device(device)
+
+    if offload_mode == "none":
+        # Original behaviour: move everything to the target device now.
+        model = model.to(inference_device)
+
+    elif offload_mode == "cpu":
+        if inference_device.type == "cpu":
+            # Nothing to offload; just stay on CPU.
+            pass
+        else:
+            # Wrap: weights live on CPU, hop to GPU only during forward().
+            model = CPUOffloadWrapper(model, inference_device)
+
+    elif offload_mode == "auto":
+        try:
+            from accelerate import dispatch_model, infer_auto_device_map
+            from accelerate.utils import get_balanced_memory
+        except ImportError as exc:
+            raise ImportError(
+                "offload_mode='auto' requires the `accelerate` package.\n"
+                "Install it with:  pip install accelerate"
+            ) from exc
+
+        max_memory = get_balanced_memory(model, no_split_module_classes=None)
+        device_map = infer_auto_device_map(
+            model, max_memory=max_memory, no_split_module_classes=None
+        )
+        print(f"Accelerate device_map: {device_map}")
+        model = dispatch_model(model, device_map=device_map)
+
+    else:
+        raise ValueError(
+            f"Unknown offload_mode {offload_mode!r}. "
+            "Choose from: 'none', 'cpu', 'auto'."
+        )
+
     return model, model_cfg
 
+
+# ---------------------------------------------------------------------------
+# HuggingFace helpers (unchanged from original, except offload_mode forwarded)
+# ---------------------------------------------------------------------------
 
 def _hf_download(repo_id):
     from huggingface_hub import snapshot_download
     local_dir = snapshot_download(repo_id=repo_id)
-    return os.path.join(local_dir, "model.ckpt"), os.path.join(local_dir, "assets", "mhr_model.pt")
+    return (
+        os.path.join(local_dir, "model.ckpt"),
+        os.path.join(local_dir, "assets", "mhr_model.pt"),
+    )
 
 
-def load_sam_3d_body_hf(repo_id, **kwargs):
+def load_sam_3d_body_hf(repo_id, offload_mode: str = "cpu", **kwargs):
     ckpt_path, mhr_path = _hf_download(repo_id)
-    return load_sam_3d_body(checkpoint_path=ckpt_path, mhr_path=mhr_path)
+    return load_sam_3d_body(
+        checkpoint_path=ckpt_path,
+        mhr_path=mhr_path,
+        offload_mode=offload_mode,
+        **kwargs,
+    )

--- a/sam_3d_body/sam_3d_body_estimator.py
+++ b/sam_3d_body/sam_3d_body_estimator.py
@@ -28,7 +28,13 @@ class SAM3DBodyEstimator:
         human_segmentor=None,
         fov_estimator=None,
     ):
-        self.device = sam_3d_body_model.device
+        # CPUOffloadWrapper keeps weights on CPU between calls; the inference
+        # device is stored on the wrapper. Fall back to reading a parameter
+        # so this works with plain nn.Module too.
+        if hasattr(sam_3d_body_model, "inference_device"):
+            self.device = sam_3d_body_model.inference_device  # CPUOffloadWrapper
+        else:
+            self.device = next(sam_3d_body_model.parameters()).device
         self.model, self.cfg = sam_3d_body_model, model_cfg
         self.detector = human_detector
         self.sam = human_segmentor
@@ -94,7 +100,8 @@ class SAM3DBodyEstimator:
         self.image_embeddings = None
         self.output = None
         self.prev_prompt = []
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
         if type(img) == str:
             img = load_image(img, backend="cv2", image_format="bgr")
@@ -157,32 +164,52 @@ class SAM3DBodyEstimator:
         batch = prepare_batch(img, self.transform, boxes, masks, masks_score)
 
         #################### Run model inference on an image ####################
-        batch = recursive_to(batch, "cuda")
-        self.model._initialize_batch(batch)
+        batch = recursive_to(batch, self.device)
 
-        # Handle camera intrinsics
-        # - either provided externally or generated via default FOV estimator
-        if cam_int is not None:
-            print("Using provided camera intrinsics...")
-            cam_int = cam_int.to(batch["img"])
-            batch["cam_int"] = cam_int.clone()
-        elif self.fov_estimator is not None:
-            print("Running FOV estimator ...")
-            input_image = batch["img_ori"][0].data
-            cam_int = self.fov_estimator.get_cam_intrinsics(input_image).to(
-                batch["img"]
+        # If the model is wrapped in CPUOffloadWrapper, run_inference() is
+        # called directly on the inner model via __getattr__, bypassing
+        # forward() and therefore bypassing the device-move logic entirely.
+        # We detect this and manage the device transfer manually here.
+        from sam_3d_body.build_models import CPUOffloadWrapper
+        _is_offloaded = isinstance(self.model, CPUOffloadWrapper)
+        _inner = self.model.inner if _is_offloaded else self.model
+
+        if _is_offloaded:
+            _inner.to(self.device)
+            CPUOffloadWrapper._move_non_persistent_buffers(_inner, self.device)
+
+        try:
+            _inner._initialize_batch(batch)
+
+            # Handle camera intrinsics
+            # - either provided externally or generated via default FOV estimator
+            if cam_int is not None:
+                print("Using provided camera intrinsics...")
+                cam_int = cam_int.to(batch["img"])
+                batch["cam_int"] = cam_int.clone()
+            elif self.fov_estimator is not None:
+                print("Running FOV estimator ...")
+                input_image = batch["img_ori"][0].data
+                cam_int = self.fov_estimator.get_cam_intrinsics(input_image).to(
+                    batch["img"]
+                )
+                batch["cam_int"] = cam_int.clone()
+            else:
+                cam_int = batch["cam_int"].clone()
+
+            outputs = _inner.run_inference(
+                img,
+                batch,
+                inference_type=inference_type,
+                transform_hand=self.transform_hand,
+                thresh_wrist_angle=self.thresh_wrist_angle,
             )
-            batch["cam_int"] = cam_int.clone()
-        else:
-            cam_int = batch["cam_int"].clone()
-
-        outputs = self.model.run_inference(
-            img,
-            batch,
-            inference_type=inference_type,
-            transform_hand=self.transform_hand,
-            thresh_wrist_angle=self.thresh_wrist_angle,
-        )
+        finally:
+            if _is_offloaded:
+                _inner.cpu()
+                CPUOffloadWrapper._move_non_persistent_buffers(_inner, torch.device("cpu"))
+                if self.device.type == "cuda":
+                    torch.cuda.empty_cache()
         if inference_type == "full":
             pose_output, batch_lhand, batch_rhand, _, _ = outputs
         else:

--- a/tools/build_detector.py
+++ b/tools/build_detector.py
@@ -9,21 +9,27 @@ from PIL import Image
 
 
 class HumanDetector:
-    def __init__(self, name="vitdet", device="cuda", **kwargs):
-        self.device = device
+    def __init__(self, name="vitdet", device="cuda", offload_mode="none", **kwargs):
+        self.device = torch.device(device)
+        self.offload_mode = offload_mode
 
         if name == "vitdet":
-            print("########### Using human detector: ViTDet...")
+            print(f"########### Using human detector: ViTDet... (offload_mode={offload_mode!r})")
+            # DetectionCheckpointer always loads to CPU internally;
+            # load_detectron2_vitdet moves to CPU explicitly after.
             self.detector = load_detectron2_vitdet(**kwargs)
             self.detector_func = run_detectron2_vitdet
 
-            self.detector = self.detector.to(self.device)
+            if offload_mode == "none":
+                # Original behaviour: keep on target device persistently
+                self.detector = self.detector.to(self.device)
+            # offload_mode="cpu": stays on CPU, moved per-call in run_human_detection
             self.detector.eval()
         elif name == "sam3":
             from sam3.model_builder import build_sam3_image_model
             from sam3.model.sam3_image_processor import Sam3Processor
-            
-            self.detector = build_sam3_image_model()
+
+            self.detector = build_sam3_image_model(device=str(self.device))
             self.processor = Sam3Processor(self.detector)
             self.detector_func = lambda detector, img, **kwargs: self.sam3_run(
                 img, **kwargs
@@ -62,7 +68,17 @@ class HumanDetector:
         return np.array(enlarged_boxes)
 
     def run_human_detection(self, img, **kwargs):
-        return self.detector_func(self.detector, img, **kwargs)
+        if self.offload_mode == "cpu" and self.device.type != "cpu":
+            self.detector.to(self.device)
+            try:
+                result = self.detector_func(self.detector, img, **kwargs)
+            finally:
+                self.detector.cpu()
+                if self.device.type == "cuda":
+                    torch.cuda.empty_cache()
+            return result
+        else:
+            return self.detector_func(self.detector, img, **kwargs)
 
 
 def load_detectron2_vitdet(path=""):
@@ -92,7 +108,9 @@ def load_detectron2_vitdet(path=""):
     detector = instantiate(detectron2_cfg.model)
     checkpointer = DetectionCheckpointer(detector)
     checkpointer.load(detectron2_cfg.train.init_checkpoint)
-
+    # DetectionCheckpointer loads to whichever device the model skeleton is on.
+    # Explicitly move to CPU so the caller controls final placement.
+    detector = detector.cpu()
     detector.eval()
     return detector
 
@@ -112,9 +130,11 @@ def run_detectron2_vitdet(
     IMAGE_SIZE = 1024
     transforms = T.ResizeShortestEdge(short_edge_length=IMAGE_SIZE, max_size=IMAGE_SIZE)
     img_transformed = transforms(T.AugInput(img)).apply_image(img)
+    # Follow the detector's actual device so this works with CPU offloading
+    _device = next(detector.parameters()).device
     img_transformed = torch.as_tensor(
         img_transformed.astype("float32").transpose(2, 0, 1)
-    )
+    ).to(_device)
     inputs = {"image": img_transformed, "height": height, "width": width}
 
     with torch.no_grad():

--- a/tools/build_fov_estimator.py
+++ b/tools/build_fov_estimator.py
@@ -4,20 +4,37 @@ import torch
 
 
 class FOVEstimator:
-    def __init__(self, name="moge2", device="cuda", **kwargs):
-        self.device = device
+    def __init__(self, name="moge2", device="cuda", offload_mode="none", **kwargs):
+        self.device = torch.device(device)
+        self.offload_mode = offload_mode
 
         if name == "moge2":
-            print("########### Using fov estimator: MoGe2...")
-            self.fov_estimator = load_moge(device, **kwargs)
+            print(f"########### Using fov estimator: MoGe2... (offload_mode={offload_mode!r})")
+            # Always load to CPU first regardless of offload_mode
+            self.fov_estimator = load_moge("cpu", **kwargs)
             self.fov_estimator_func = run_moge
-
             self.fov_estimator.eval()
+
+            if offload_mode == "none":
+                # Original behaviour: move to target device now
+                self.fov_estimator = self.fov_estimator.to(self.device)
+            # offload_mode="cpu": stays in RAM, moved per-call in get_cam_intrinsics
         else:
             raise NotImplementedError
 
     def get_cam_intrinsics(self, img, **kwargs):
-        return self.fov_estimator_func(self.fov_estimator, img, self.device, **kwargs)
+        if self.offload_mode == "cpu" and self.device.type != "cpu":
+            self.fov_estimator.to(self.device)
+            try:
+                result = self.fov_estimator_func(self.fov_estimator, img, self.device, **kwargs)
+            finally:
+                self.fov_estimator.cpu()
+                if self.device.type == "cuda":
+                    torch.cuda.empty_cache()
+            return result
+        else:
+            _device = next(self.fov_estimator.parameters()).device
+            return self.fov_estimator_func(self.fov_estimator, img, _device, **kwargs)
 
 
 def load_moge(device, path=""):
@@ -25,6 +42,7 @@ def load_moge(device, path=""):
 
     if path == "":
         path = "Ruicheng/moge-2-vitl-normal"
+    # Always load to CPU first; caller decides final device placement
     moge_model = MoGeModel.from_pretrained(path).to(device)
     return moge_model
 
@@ -32,8 +50,10 @@ def load_moge(device, path=""):
 def run_moge(model, input_image, device):
     # We expect the image to be RGB already
     H, W, _ = input_image.shape
+    # Derive device from model parameters so this works with CPU offloading
+    _device = next(model.parameters()).device
     input_image = torch.tensor(
-        input_image / 255, dtype=torch.float32, device=device
+        input_image / 255, dtype=torch.float32, device=_device
     ).permute(2, 0, 1)
 
     # Infer w/ MoGe2

--- a/tools/build_sam.py
+++ b/tools/build_sam.py
@@ -6,22 +6,37 @@ from PIL import Image
 
 
 class HumanSegmentor:
-    def __init__(self, name="sam2", device="cuda", **kwargs):
-        self.device = device
+    def __init__(self, name="sam2", device="cuda", offload_mode="none", **kwargs):
+        self.device = torch.device(device)
+        self.offload_mode = offload_mode
 
         if name == "sam2":
-            print("########### Using human segmentor: SAM2...")
-            self.sam = load_sam2(device, **kwargs)
+            print(f"########### Using human segmentor: SAM2... (offload_mode={offload_mode!r})")
+            if offload_mode == "cpu":
+                # Load to CPU; move to device only during run_sam
+                self.sam = load_sam2("cpu", **kwargs)
+            else:
+                self.sam = load_sam2(device, **kwargs)
             self.sam_func = run_sam2
         elif name == "sam3":
-            print("########### Using human segmentor: SAM3...")
+            print(f"########### Using human segmentor: SAM3... (offload_mode={offload_mode!r})")
             self.sam = load_sam3(device, **kwargs)
             self.sam_func = run_sam3
         else:
             raise NotImplementedError
-    
+
     def run_sam(self, img, boxes, **kwargs):
-        return self.sam_func(self.sam, img, boxes)
+        if self.offload_mode == "cpu" and self.device.type != "cpu":
+            self.sam.model.to(self.device)
+            try:
+                result = self.sam_func(self.sam, img, boxes)
+            finally:
+                self.sam.model.cpu()
+                if self.device.type == "cuda":
+                    torch.cuda.empty_cache()
+            return result
+        else:
+            return self.sam_func(self.sam, img, boxes)
         
 
 def load_sam2(device, path):
@@ -42,14 +57,16 @@ def load_sam2(device, path):
 def load_sam3(device, path):
     from sam3.model_builder import build_sam3_image_model
     from sam3.model.sam3_image_processor import Sam3Processor
-    
-    model = build_sam3_image_model()
+
+    model = build_sam3_image_model(device=device)
     predictor = Sam3Processor(model)
     return predictor
 
 
 def run_sam2(sam_predictor, img, boxes):
-    with torch.autocast("cuda", dtype=torch.bfloat16):
+    _device = next(sam_predictor.model.parameters()).device
+    _dtype = torch.bfloat16 if _device.type == "cuda" else torch.float32
+    with torch.autocast(_device.type, dtype=_dtype):
         sam_predictor.set_image(img)
         all_masks, all_scores = [], []
         for i in range(boxes.shape[0]):


### PR DESCRIPTION
This is a custom version of SAM 3D Body that I've been experimenting with. **The ultimate goal is to help run the model in resource-constrained environments**.

### Major add-ons
- Model backbones and detectors and loaded onto CPU RAM.
- Peak VRAM usage has significantly decreased (max was around 6.5 Gb) as I will show later after the changes, although it comes with small a trade-off in processing speed.

### Changes
**Core model files**
1. `sam_3d_body/build_models.py` :
- Added a `CPUOffloadWrapper` class to `sam_3d_body/build_models.py` to move parameters and non-persistent buffers to GPU during inference time and back to CPU RAM. Also, added a `offload_mode` parameter to `load_sam_3d_body` function. **For testing purposes, it defaults to 'CPU'**.

2. `sam_3d_body/models/meta_arch/sam3d_body.py` : 
- Replaced all hardcoded `.cuda()` and `recursive_to(..., "cuda")` with device-aware equivalents

3. `sam_3d_body/sam_3d_body_estimator.py` : 
- Fixed device resolution in `__init__`, replaced `recursive_to(batch, "cuda")` with `self.device`, added explicit device management around `run_inference()` since it bypasses `CPUOffloadWrapper.forward()`.

**Tools files**
1. `tools/build_detector.py` :
- Added `offload_mode` parameter, CPU load for ViTDet, device-aware input tensor, per-call GPU hop in `run_human_detection()`.

2. `tools/build_fov_estimator.py` : 
- Added `offload_mode` parameter, CPU load for MoGe2, per-call GPU hop in `get_cam_intrinsics()`, fixed `run_moge()` tensor device.

3. `tools/build_sam.py` : 
- Added `offload_mode` parameter, CPU load for SAM2, per-call GPU hop in `run_sam()`, fixed hardcoded `torch.autocast("cuda")`.

**Notebook utils**
1. `notebook/utils.py` :
- added `offload_mode="cpu"` parameter to `setup_sam_3d_body()` function and forwarded it to all four model constructors.

### Testing environment
This version of the code was tested on a Kaggle environment for a custom workflow (injury prediction for soccer players) with the following main specs:
- RAM: 32 GB
- Accelerator: T4 X 2
- Python: 3.12.12
- torch: 2.9.0 compiled with CUDA 12.6

### Benchmarks
- Loading the model
<img width="218" height="612" alt="image" src="https://github.com/user-attachments/assets/e55f630d-e143-42c1-815f-e287a453b32e" />
<img width="637" height="222" alt="image" src="https://github.com/user-attachments/assets/4058fb56-0711-4be6-a332-0beb46576af4" />

- Peak VRAM used during inference
<img width="216" height="634" alt="image" src="https://github.com/user-attachments/assets/9c102751-381b-4d3e-b429-0bb386512fd5" />

I would be happy to share the notebook if I knew under which license to put this version of the source code, since I used it as a private dataset.
Happy to discuss this optimization further!